### PR TITLE
style: add padding to 01/landing

### DIFF
--- a/src/sections/Landing.jsx
+++ b/src/sections/Landing.jsx
@@ -40,7 +40,7 @@ const Landing = () => {
   }, [])
 
   return (
-    <section className='flex flex-col justify-center h-[calc(100vh-96px)] typography'>
+    <section className='flex flex-col justify-center h-[calc(100vh-96px)] p-8 typography'>
       <h1 className='text-9xl cursor-pointer' onClick={clicked}>{header}</h1>
       <h2 className='font-normal mb-4'>November 3-5, 2023 | Time. <span className='text-accent1'>Reinvented.</span></h2>
       <div className='mb-[7rem] flex items-center gap-2'>


### PR DESCRIPTION
(You may treat this as a joke pull request)

<img width="1260" alt="image" src="https://github.com/ClockHacks/clockhacks.dev/assets/105888573/58d767e2-0096-4acd-ba76-0e4e7de094d9">
<br>
There isn't any whitespace that separates the landing text from the left side of the screen. This makes it look slightly unprofessional. 

### Description of changes
- Added some padding